### PR TITLE
Check for a Redhat-style system. Use 'lua' instead of 'lua5.2' if so.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,14 @@ all: unix
 else
 	LIBROOT ?= /usr/lib
 	INCROOT := /usr
+	# Redhat and Debian systems have different names for the lua packages
+	ifeq ($(wildcard /etc/redhat-release),)
+		# Debian
+		LUA_PACKAGE = lua5.2
+	else
+		# Redhat, Fedora
+		LUA_PACKAGE = lua
+	endif
 	ifeq ($(USE_LUAJIT),y)
 		LUA_INCLUDE := $(INCROOT)/include/luajit-2.0
 		LUA_LIB := -lluajit-5.1


### PR DESCRIPTION
Fixes #23. (Note that this patch is included in the forthcoming Fedora
package)