### PR TITLE
Update the Fedora package names

### DIFF
--- a/README
+++ b/README
@@ -57,7 +57,7 @@ packages:
     ninja-build libncursesw5-dev liblua5.2-dev zlib1g-dev libxft-dev
 
   If you have Fedora:
-    luajit luajit-devel compat-lua-libs compat-lua-devel compat-lua lua-filesystem-compat zlib-devel libXft-devel
+    lua lua-devel lua-libs lua-filesystem zlib-devel libXft-devel ncurses ncurses-devel ninja-build
 
   If you have OSX with Homebrew (ncurses only, sorry):
     ninja


### PR DESCRIPTION
Based on the lastest spec file in https://src.fedoraproject.org/rpms/wordgrinder/blob/master/f/wordgrinder.spec