### PR TITLE
New option for estimating number of pages

### DIFF
--- a/src/lua/document.lua
+++ b/src/lua/document.lua
@@ -228,6 +228,7 @@ DocumentClass =
 		-- These should no longer exist; this dates from a previous attempt
 		-- at undo with file version 6. We're not storing the undo buffer
 		-- in files any more.
+		-- lol XD this is the content of so many programming memes
 		self.undostack = nil
 		self.redostack = nil
 	end,

--- a/src/lua/fileio.lua
+++ b/src/lua/fileio.lua
@@ -726,4 +726,13 @@ function UpgradeDocument(oldversion)
         end
 		DocumentSet.styles = nil
 	end
+	
+	-- Upgrade version 7 to 8!
+	
+	if (oldversion < 8) then
+		--this version is where the number of lines is a tracked value, and two fields were
+		--added to the pagecount addon
+
+		Document.linecount = nil
+	end
 end

--- a/src/lua/redraw.lua
+++ b/src/lua/redraw.lua
@@ -301,3 +301,22 @@ do
 
 	AddEventListener(Event.Changed, cb)
 end
+
+-----------------------------------------------------------------------------
+--Maintains the line count field in the current document.
+
+do
+	local function cb(event, token)
+		local lc = 0
+		local nl = 0
+
+		for _, p in ipairs(Document) do
+			lc = lc + #p:wrap()
+
+		end
+
+		Document.linecount = lc
+	end
+
+	AddEventListener(Event.Changed, cb)
+end


### PR DESCRIPTION
This adds two more options to the page count settings

- estimate pages by lines of words (value stored in pagesbylines)
- a textfield to enter the number of lines in each page (value stored in linesperpage)

when pagesbylines is true, wordsperpage is ignored and linesperpage is used to calculate the number of pages, and vice versa

The number of lines is kept track of at the bottom of src/lua/redraw.lua by totaling the number of lines returned by wrap() for each paragraph. This is then stored in Document.linecount.