### PR TITLE
112 - Improve spellecheck case handling

### DIFF
--- a/src/lua/addons/spillchocker.lua
+++ b/src/lua/addons/spillchocker.lua
@@ -85,7 +85,8 @@ local function get_user_dictionary_document()
 	return d
 end
 
-function GetUserDictionary()
+function GetUserDictionary(preserve_case)
+    local pc = preserve_case or false
 	if not user_dictionary_cache then
 		local d = get_user_dictionary_document()
 		user_dictionary_cache = {}
@@ -93,7 +94,7 @@ function GetUserDictionary()
 		local vstyle = DocumentSet.styles["V"]
 		for _, p in ipairs(d) do
 			if (p.style == "V") then
-				local w = GetWordSimpleText(p[1])
+				local w = GetWordSimpleText(p[1], preserve_case)
 				user_dictionary_cache[w] = true
 			end
 		end
@@ -128,12 +129,18 @@ function IsWordMisspelt(word)
 	local settings = DocumentSet.addons.spellchecker or {}
 	if settings.enabled then
 		local misspelt = true
-		local s = GetWordSimpleText(word)
-		if (s == "")
-			or (not s:find("[a-zA-Z]"))
-			or (#s < 3)
-			or (settings.usesystemdictionary and GetSystemDictionary()[s])
-			or (settings.useuserdictionary and GetUserDictionary()[s])
+		local sci = GetWordSimpleText(word) -- case insensitive
+		local scs = GetWordSimpleText(word, true) -- case sensitive
+		if (sci == "")
+			or (not sci:find("[a-zA-Z]"))
+			or (#sci < 3)
+			or (settings.usesystemdictionary and GetSystemDictionary()[scs])
+			or (settings.useuserdictionary and GetUserDictionary(true)[scs])
+
+			or (settings.usesystemdictionary and OnlyFirstCharIsUppercase(scs) and GetSystemDictionary()[sci])
+
+			or (settings.useuserdictionary and OnlyFirstCharIsUppercase(scs) and GetUserDictionary()[sci])
+
 		then
 			misspelt = false
 		end

--- a/src/lua/document.lua
+++ b/src/lua/document.lua
@@ -526,14 +526,29 @@ function GetOffsetFromWidth(s, x)
 		return len + 1
 end
 
-function GetWordSimpleText(s)
+function GetWordSimpleText(s, preserve_case)
+    local pc = preserve_case or false
 	s = GetWordText(s)
 	s = UnSmartquotify(s)
 	s = s:gsub('[~#&^$"<>]+', "")
 	s = s:gsub("^[.'([{]+", "")
 	s = s:gsub("[',.!?:;)%]}]+$", "")
-	s = s:lower()
+    if not preserve_case then
+        s = s:lower()
+    end
 	return s
+end
+
+function OnlyFirstCharIsUppercase(s)
+    -- Return true if only first character is uppercase
+    local first_char = s:sub(0, 1)
+    if first_char:upper() == first_char then
+        local remaining_chars = s:sub(2, s:len())
+        if remaining_chars:lower() == remaining_chars then
+            return true
+        end
+    end
+    return false
 end
 
 function UpdateDocumentStyles()


### PR DESCRIPTION
If a word has a case-sensitive dictionary match, it passes spellcheck.
If the first character of a word is the only uppercase character, and it
has a case-insensitive dictionary match, it passes spellcheck.
This is not perfect, but I believe it is an improvement over the
previous implementation.

#112 