### PR TITLE
Makefile: Allow `OBJDIR` to be set by the caller

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ MANDIR ?= $(PREFIX)/share/man
 DESTDIR ?=
 
 # Where do the temporary files go?
-OBJDIR = /tmp/wg-build
+OBJDIR ?= /tmp/wg-build
 
 # The compiler used for the native build (curses, X11)
 CC ?= cc


### PR DESCRIPTION
Build systems such as the one for [Nix/NixOS]() tries to guarantee the
purity of the builds; Sadly, hardcoding `/tmp/wg-build` breaks this
and makes it complain.

Signed-off-by: Pamplemousse <xav.maso@gmail.com>