### PR TITLE
Add a user script for concatenating all subdocuments in a file.

### DIFF
--- a/scripts/concat.lua
+++ b/scripts/concat.lua
@@ -1,0 +1,57 @@
+-- © 2020 David Given.
+-- WordGrinder is licensed under the MIT open source license. See the COPYING
+-- file in this distribution for the full text.
+
+-- This user script will concatenate all subdocuments in a file into a single one.
+--
+-- To use:
+--
+--     wordgrinder --lua concat.lua "mynovel.wg output.wg"
+--
+-- (Note the quoting.)
+--
+-- If mynovel.wg contains subdocuments called Foo, Bar and Baz, this will
+-- create a single file called output.wg with the contents of all the
+-- subdocuments moved into a new subdocument called 'all'.
+
+-- Main program
+
+local function main(args)
+    local inputfile, outputfile = unpack(SplitString(args, " "))
+
+	if not outputfile then
+		print("Syntax: wordgrinder --lua concat.lua '<inputfile.wg> <outputfile.wg>'")
+		os.exit(1)
+	end
+
+    if not Cmd.LoadDocumentSet(inputfile) then
+        print("failed to load document")
+        os.exit(1)
+    end
+
+	if DocumentSet:findDocument("all") then
+		print("The input file already has a subdocument called 'all'.")
+		os.exit(1)
+	end
+
+	local docs = { unpack(DocumentSet:getDocumentList()) }
+	local allDoc = DocumentSet:addDocument(CreateDocument(), "all")
+    for _, doc in ipairs(docs) do
+		for _, p in ipairs(doc) do
+			allDoc[#allDoc+1] = p
+		end
+
+		DocumentSet:deleteDocument(doc.name)
+    end
+
+	if not Cmd.SaveCurrentDocumentAs(outputfile) then
+		print("failed to save new document")
+		os.exit(1)
+	end
+end
+
+main(...)
+os.exit(0)
+
+
+

--- a/src/lua/document.lua
+++ b/src/lua/document.lua
@@ -89,6 +89,7 @@ DocumentSetClass =
 
 		self:touch()
 		RebuildDocumentsMenu(self.documents)
+		return document
 	end,
 
 	moveDocumentIndexTo = function(self, name, targetIndex)


### PR DESCRIPTION
This solves the use case where each chapter of a book is in its own subdocument (which I've done myself).

Fixes: #108 