### PR TITLE
Add double-buffering to Windows GDI graphics drawing.

### DIFF
--- a/README
+++ b/README
@@ -149,8 +149,7 @@ WordGrinder 0.8: 2020-xx-xx: bugfix release (mostly). New features: a paragraph
 style for numbered bulletpoints; more look-and-feel options; the caret now
 flashes; basic template support; word count display of selected text. Bugfixes:
 lots of import and export fixes (and tests so that they stay fixed);
-spellchecker fixes; selection position fixes; keyboard entry fixes on Windows;
-assorted other minor tweaks.
+spellchecker fixes; selection position fixes; keyboard entry fixes on Windows; graphics fixes on Windows; assorted other minor tweaks.
 
 WordGrinder 0.7.2: 2018-11-29: bugfix release. Pasting immediately after
 loading a document no longer hard crashes. Don't buffer overrun if given


### PR DESCRIPTION
This both improves performance and eliminates flickering entirely.

Fixes: #45 
Fixes: #126 