### PR TITLE
Fix poor handling of --lua.

### DIFF
--- a/README.wg
+++ b/README.wg
@@ -57,7 +57,7 @@ WordGrinder dumpfile v3: this is a text file; diff me!
 .documents.3.viewmode: 2
 .documents.3.wordcount: 161
 .fileformat: 8
-.findtext: "wordgrinder.lua"
+.findtext: "--lua"
 .idletime: 3
 .menu.accelerators.BACKSPACE: "ZDPC"
 .menu.accelerators.DELETE: "ZDNC"
@@ -259,7 +259,7 @@ P To use, run this command:
 Q wordgrinder --help
 P This will show the command line options, and at the bottom will tell you where your configuration file lives. Open this in a (non-WordGrinder) text editor.
 P Now run:
-Q wordgrinder --lua "ListMenuItems()"
+Q wordgrinder --exec "ListMenuItems()"
 P WordGrinder will display all the menu items it knows about, plus their menu ID. You can now enter lines like this in your configuration file:
 Q OverrideKey("^Z", "ZM")
 Q OverrideKey("F1", "D1")
@@ -333,7 +333,7 @@ P WordGrinder supports standard wordlist dictionaries which are just a big text 
 P Each document set also carries with it a user dictionary; this is just another document in the document set. It contains a list of words which will be considered correctly spelt. Words can be added to this with Edit→Spellchecker→Add current word to dictionary. Alternatively the user dictionary can be modified at any time.
 P You can jump to the next misspelt word with Edit→Spellchecker→Find next misspelt word.
 H3 Command line
-P There are some WordGrinder features which can be used from the command line, both on Unix and Windows. Firstly, it’s completely scriptable in Lua: write a file in Lua, then run WordGrinder with wordgrinder --lua filename.lua and it’ll run and then exit. Or use wordgrinder --lua "lua command". Nearly all of WordGrinder is written in Lua and it’s all available via this interface. The API is, unfortunately, beyond the scope of this document; if you’re interested, ask the author (or look at the source code).
+P There are some WordGrinder features which can be used from the command line, both on Unix and Windows. Firstly, it’s completely scriptable in Lua: write a file in Lua, then run WordGrinder with wordgrinder --lua filename.lua and it’ll run and then exit. Or use wordgrinder --exec "lua command". Nearly all of WordGrinder is written in Lua and it’s all available via this interface. The API is, unfortunately, beyond the scope of this document; if you’re interested, ask the author (or look at the source code).
 P Secondly, the file .wordgrinder/startup.lua in your home directory will be automatically loaded and run whenever WordGrinder starts; see the section above on configuring WordGrinder for information.
 P Thirdly, you can use WordGrinder to automatically convert between any supported document formats. For example:
 Q wordgrinder --convert sourcefile.wg destfile.odt

--- a/src/lua/main.lua
+++ b/src/lua/main.lua
@@ -261,7 +261,8 @@ Syntax: wordgrinder [<options...>] [<filename>]
 Options:
    -h    --help                Displays this message.
          --lua file.lua        Loads and executes file.lua and then exits
-		                       (or file.lua can be some Lua statements)
+							   (remaining arguments are passed to the script)
+         --exec 'lua code'     Loads and executes the supplied code and then exits
 							   (remaining arguments are passed to the script)
    -c    --convert src dest    Converts from one file format to another
          --config file.lua     Sets the name of the user config file
@@ -294,9 +295,20 @@ the program starts up (but after any --lua files). It defaults to:
 			end
 
 			local f, e = loadfile(opt)
-			if e and e:find("No such file or directory") then
-				f, e = loadstring(opt)
+			if e then
+				CLIError("user script compilation error: "..e)
 			end
+
+			f(...)
+			os.exit(0)
+		end
+
+		local function do_exec(opt, ...)
+			if not opt then
+				CLIError("--exec must have an argument")
+			end
+
+			local f, e = loadstring(opt)
 			if e then
 				CLIError("user script compilation error: "..e)
 			end
@@ -339,6 +351,7 @@ the program starts up (but after any --lua files). It defaults to:
 			["h"]          = do_help,
 			["help"]       = do_help,
 			["lua"]        = do_lua,
+			["exec"]       = do_exec,
 			["c"]          = do_convert,
 			["convert"]    = do_convert,
 			["config"]     = do_config,


### PR DESCRIPTION
If you pass a user script filename which doesn't exist to --lua, you get a really unhelpful error message because it's parsed as Lua source. This change moves the inline script flag to --exec so we can return proper error messages.