### PR TITLE
Remove/stop using legacy bits

### DIFF
--- a/configure
+++ b/configure
@@ -518,7 +518,6 @@ add_nsis() {
 
 add_install() {
     install_file extras/wordgrinder.desktop $PREFIX/share/applications/wordgrinder.desktop 644
-    install_file extras/wordgrinder.mime    $PREFIX/share/mime-info/wordgrinder.mime 644
     install_file extras/wordgrinder.xml     $PREFIX/share/mime/packages/wordgrinder.xml 644
     install_file extras/icon.png            $PREFIX/share/icons/hicolor/256x256/apps/wordgrinder.png 644
     install_file README.wg                  $PREFIX/doc/wordgrinder/README.wg 644

--- a/configure
+++ b/configure
@@ -519,6 +519,7 @@ add_nsis() {
 add_install() {
     install_file extras/wordgrinder.desktop $PREFIX/share/applications/wordgrinder.desktop 644
     install_file extras/wordgrinder.mime    $PREFIX/share/mime-info/wordgrinder.mime 644
+    install_file extras/wordgrinder.xml     $PREFIX/share/mime/packages/wordgrinder.xml 644
     install_file extras/icon.png            $PREFIX/share/icons/hicolor/256x256/apps/wordgrinder.png 644
     install_file README.wg                  $PREFIX/doc/wordgrinder/README.wg 644
     install_file $OBJDIR/wordgrinder.1      $PREFIX/man/man1/wordgrinder.1 644

--- a/configure
+++ b/configure
@@ -519,7 +519,7 @@ add_nsis() {
 add_install() {
     install_file extras/wordgrinder.desktop $PREFIX/share/applications/wordgrinder.desktop 644
     install_file extras/wordgrinder.mime    $PREFIX/share/mime-info/wordgrinder.mime 644
-    install_file extras/icon.png            $PREFIX/share/pixmaps/wordgrinder.png 644
+    install_file extras/icon.png            $PREFIX/share/icons/hicolor/256x256/apps/wordgrinder.png 644
     install_file README.wg                  $PREFIX/doc/wordgrinder/README.wg 644
     install_file $OBJDIR/wordgrinder.1      $PREFIX/man/man1/wordgrinder.1 644
     install_file $OBJDIR/xwordgrinder.1     $PREFIX/man/man1/xwordgrinder.1 644

--- a/extras/wordgrinder.mime
+++ b/extras/wordgrinder.mime
@@ -1,2 +1,0 @@
-application/x-wordgrinder
-	ext: wg

--- a/extras/wordgrinder.xml
+++ b/extras/wordgrinder.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<mime-info xmlns="http://www.freedesktop.org/standards/shared-mime-info">
+  <mime-type type="application/x-wordgrinder">
+    <comment>WordGrinder document</comment>
+    <glob pattern="*.wg"/>
+  </mime-type>
+</mime-info>


### PR DESCRIPTION
- drop the old GNOME mime, and replace it with a XDG mime type
- install the application icon in the XDG icon theme rather than the legacy `/usr/share/pixmaps` location