### PR TITLE
Modifying the PRE and RAW Styles + Provide a Docker build environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:latest
+FROM debian:stable AS builder
 
 RUN apt-get update && apt-get install -y build-essential ninja-build libncursesw5-dev liblua5.2-dev zlib1g-dev libxft-dev
 
@@ -8,8 +8,9 @@ WORKDIR /app
 
 RUN make
 
-#binaries end up under bin/ directory!
-RUN cp bin/wordgrinder-builtin-curses-release /bin/wordgrinder
+FROM debian:stable-slim
+
+COPY --from=builder /app/bin/wordgrinder-builtin-curses-release /bin/wordgrinder
 
 CMD /bin/wordgrinder
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM debian:latest
+
+RUN apt-get update && apt-get install -y build-essential ninja-build libncursesw5-dev liblua5.2-dev zlib1g-dev libxft-dev
+
+COPY . /app
+
+WORKDIR /app
+
+RUN make
+
+#binaries end up under bin/ directory!
+RUN cp bin/wordgrinder-builtin-curses-release /bin/wordgrinder
+
+CMD /bin/wordgrinder
+
+

--- a/src/lua/document.lua
+++ b/src/lua/document.lua
@@ -29,7 +29,8 @@ local stylemarkup =
 	["H2"] = BRIGHT + BOLD + UNDERLINE,
 	["H3"] = ITALIC + BRIGHT + BOLD,
 	["H4"] = BRIGHT + BOLD,
-	["PRE"] = BRIGHT + ITALIC
+	["PRE"] = BRIGHT + ITALIC,
+	["RAW"] = BRIGHT + BOLD
 }
 
 DocumentSetClass =

--- a/src/lua/document.lua
+++ b/src/lua/document.lua
@@ -28,7 +28,8 @@ local stylemarkup =
 	["H1"] = ITALIC + BRIGHT + BOLD + UNDERLINE,
 	["H2"] = BRIGHT + BOLD + UNDERLINE,
 	["H3"] = ITALIC + BRIGHT + BOLD,
-	["H4"] = BRIGHT + BOLD
+	["H4"] = BRIGHT + BOLD,
+	["PRE"] = BRIGHT + ITALIC
 }
 
 DocumentSetClass =

--- a/src/lua/export/markdown.lua
+++ b/src/lua/export/markdown.lua
@@ -3,7 +3,8 @@ local function unmarkdown(s)
 	s = s:gsub("- ", "\\- ")
 	s = s:gsub("<", "\\<")
 	s = s:gsub(">", "\\>")
-	s = s:gsub("`", "\\`")
+	--allows for inline preformatted text in markdown
+	--s = s:gsub("`", "\\`")
 	s = s:gsub("_", "\\_")
 	s = s:gsub("*", "\\*")
 	return s


### PR DESCRIPTION
@davidgiven,

Thank you so much for this fantastic tool we can use to write from the comforts of our own terminal. In general, I do a lot of technical writing in my day job and also on my personal blog. I modified the RAW and Preformatted text styles so they are visually distinct from the surrounding plain text. This way, users can tell they have applied the given style to the selected area and improve readability. 

Another area that I think would be very helpful is if WordGrinder supported inline preformatted text.  For example, in my technical writings I often blurbs like the following: 

_WordGrinder is a free and opensource word processor for your terminal. To start wordgrinder, simply execute the `wordgrinder` command followed by any additional arguments.._

To get around this, since I simply export most of my documents to markdown, I removed the substitution filter from the markdown export for backticks.  This allows me to use to surround the in-line preformatted text with backticks and once exported to markdown, gives me the desired result. However, this is a work around. I tried implementing a preformatted text style similar to the way you did with bold, italic, and underline but I got lost between the C and LUA code. Everything blew up and I just reverted the change. Is this something you'd consider implementing in the future? 

Finally,  I am contributing a Dockerfile that will allow users to build wordgrinder inside of a Docker container. You can also run wordgrinder containerized and completely isolated from other processes on your system using this approach. I do containers for a living, so I like to containerize everything I can 👍 

Let me know if you'd be interested in incorporating these changes. I really appreciate the work you do! 