### PR TITLE
Don't crash when using SDL in debug mode.

### DIFF
--- a/src/c/arch/sdl/dpy.c
+++ b/src/c/arch/sdl/dpy.c
@@ -141,7 +141,7 @@ void dpy_start(void)
     window = SDL_CreateWindow(
             "WordGrinder",
             SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED,
-            640, 480,
+            ivar_or_default("WINDOW_WIDTH", 800), ivar_or_default("WINDOW_HEIGHT", 600),
             SDL_WINDOW_SHOWN | SDL_WINDOW_RESIZABLE
     );
     if (!window)

--- a/src/lua/_prologue.lua
+++ b/src/lua/_prologue.lua
@@ -22,13 +22,13 @@ end
 if DEBUG then
 	local allowed = 
 	{
-		X11_BLACK_COLOUR = true,
-		X11_BOLD_MODIFIER = true,
-		X11_BRIGHT_COLOUR = true,
-		X11_DIM_COLOUR = true,
-		X11_FONT = true,
-		X11_ITALIC_MODIFIER = true,
-		X11_NORMAL_COLOUR = true,
+		FONT_REGULAR = true,
+		FONT_BOLD = true,
+		FONT_ITALIC = true,
+		FONT_BOLDITALIC = true,
+		FONT_SIZE = true,
+		WINDOW_WIDTH = true,
+		WINDOW_HEIGHT = true,
 	}
 
 	setmetatable(_G,


### PR DESCRIPTION
Also add initial window size settings.

Fixes: #170 