### PR TITLE
Fix forward delete immediately after typing a space.

### DIFF
--- a/configure
+++ b/configure
@@ -487,6 +487,7 @@ add_configuration() {
         add tests tests/weirdness-delete-word.lua
         add tests tests/weirdness-deletion-with-multiple-spaces.lua
         add tests tests/weirdness-end-of-lines.lua
+        add tests tests/weirdness-forward-delete.lua
         add tests tests/weirdness-globals-applied-on-startup.lua
         add tests tests/weirdness-missing-clipboard.lua
         add tests tests/weirdness-replacing-words.lua
@@ -498,6 +499,7 @@ add_configuration() {
         add tests tests/weirdness-upgrade-0.6-with-clipboard.lua
         add tests tests/weirdness-word-left-from-end-of-line.lua
         add tests tests/weirdness-word-right-to-last-word-in-doc.lua
+        add tests tests/word.lua
         add tests tests/windows-installdir.lua
         add tests tests/xpattern.lua
 

--- a/src/lua/document.lua
+++ b/src/lua/document.lua
@@ -177,6 +177,10 @@ DocumentSetClass =
 
 DocumentClass =
 {
+	cursor = function(self)
+		return { self.cp, self.cw, self.co }
+	end,
+
 	appendParagraph = function(self, p)
 		self[#self+1] = p
 	end,

--- a/src/lua/navigate.lua
+++ b/src/lua/navigate.lua
@@ -317,9 +317,13 @@ function Cmd.DeleteNextChar()
 		return Cmd.JoinWithNextWord()
 	end
 
+	local left = DeleteFromWord(word, co, #word+1)
+	local right = DeleteFromWord(word, 1, nextco)
+	Document.co = #left + 1
+
 	Document[cp] = CreateParagraph(paragraph.style,
 		paragraph:sub(1, cw-1),
-		DeleteFromWord(word, co, nextco),
+		left..right,
 		paragraph:sub(cw+1))
 
 	DocumentSet:touch()

--- a/tests/weirdness-forward-delete.lua
+++ b/tests/weirdness-forward-delete.lua
@@ -1,0 +1,10 @@
+require("tests/testsuite")
+
+Cmd.InsertStringIntoParagraph("abcd")
+Cmd.GotoBeginningOfParagraph()
+Cmd.InsertStringIntoParagraph(" ")
+Cmd.DeleteNextChar()
+
+AssertTableEquals({"bcd", style="P"}, Document[1])
+AssertTableEquals({1, 1, 1}, Document:cursor())
+

--- a/tests/word.lua
+++ b/tests/word.lua
@@ -1,0 +1,22 @@
+local GetBytesOfCharacter = wg.getbytesofcharacter
+local GetStringWidth = wg.getstringwidth
+local NextCharInWord = wg.nextcharinword
+local PrevCharInWord = wg.prevcharinword
+local InsertIntoWord = wg.insertintoword
+local DeleteFromWord = wg.deletefromword
+local ApplyStyleToWord = wg.applystyletoword
+local GetStyleFromWord = wg.getstylefromword
+local CreateStyleByte = wg.createstylebyte
+local ReadU8 = wg.readu8
+local WriteU8 = wg.writeu8
+
+require("tests/testsuite")
+
+AssertEquals(NextCharInWord("abcd", 1), 2)
+AssertEquals(NextCharInWord("\016abcd", 2), 3)
+AssertEquals(NextCharInWord("\016abcd", 1), 3)
+
+AssertEquals(DeleteFromWord("abcd", 2, 4), "ad")
+AssertEquals(DeleteFromWord("abcd", 1, 3), "cd")
+AssertEquals(DeleteFromWord("abcd", 2, 4), "ad")
+


### PR DESCRIPTION
This was caused by mishandling the priming character added to the beginning of the next word after typing a space (to properly propagate the character style in the previous word). Deleting the first character caused the priming character to be lost, resulting in the cursor being in the wrong place.

Fixes: #187 