### PR TITLE
ESCAPE can be used to cancel things.

### DIFF
--- a/README
+++ b/README
@@ -165,7 +165,8 @@ replaced them with SDL --- there's now a GUI version for OSX! Also threw away
 and replaced the build.lua file. Added the ability to quit WordGrinder by
 closing the window. Fixed a bug where the global settings would be reset during
 CLI use. WordGrinder files with CRLF line endings can now be read. Emacs
-orgmode export (contributed by VitorGoatman@github).
+orgmode export (contributed by VitorGoatman@github). ESCAPE can be used to
+cancel things.
 
 WordGrinder 0.8: 2020-10-13: started out as a bugfix release but then I got
 carried away. New features: a paragraph style for numbered bulletpoints; more

--- a/configure
+++ b/configure
@@ -196,7 +196,6 @@ reset_configuration() {
     FRONTEND=
     SRCS=
     OBJS=
-    ARCH=normal
     BUILTIN_LUA=y
     BUILTIN_LUABITOP=y
     BUILTIN_LPEG=y
@@ -212,7 +211,6 @@ reset_configuration() {
 
     add CFLAGS -g
     add CFLAGS -DVERSION=$VERSION
-    add CFLAGS -DARCH=$ARCH
     add CFLAGS -DFILEFORMAT=$FILEFORMAT
     add CFLAGS -DNOUNCRYPT
     add CFLAGS -DNOCRYPT
@@ -263,6 +261,7 @@ add_configuration() {
     if [ "$WINDOWS" = "y" ]; then
         add CFLAGS -DEMULATED_WCWIDTH
         add CFLAGS -DWINSHIM
+        add CFLAGS -DARCH=windows
         add LDFLAGS -static
         add OBJS $OBJDIR/wordgrinder.rc.o
         add SRCS src/c/emu/wcwidth.c
@@ -278,6 +277,8 @@ add_configuration() {
             echo "build $OBJDIR/wordgrinder.rc.o: rcfile src/c/arch/win32/wordgrinder.rc | src/c/arch/win32/manifest.xml" >&3
             echo "  windres = i686-w64-mingw32-windres" >&3
         fi
+    else
+        add CFLAGS -DARCH=normal
     fi
 
     # External dependencies
@@ -366,6 +367,7 @@ add_configuration() {
     case $FRONTEND in
         ncurses)
             add SRCS src/c/arch/ncurses/dpy.c
+            add CFLAGS -DFRONTEND=ncurses
             ;;
 
         wincon)
@@ -373,6 +375,7 @@ add_configuration() {
             add SRCS src/c/arch/win32/console/realmain.c
             add CFLAGS -Dmain=appMain
             add CFLAGS -mconsole
+            add CFLAGS -DFRONTEND=wincon
             add LDFLAGS -mconsole
             ;;
 
@@ -382,6 +385,7 @@ add_configuration() {
             add SRCS src/c/emu/SDL_FontCache/SDL_FontCache.c
             add SRCS $OBJDIR/fonts.c
             add SRCS $OBJDIR/icon.c
+            add CFLAGS -DFRONTEND=sdl
             add CFLAGS $(sdl2-config --cflags) $($PKG_CONFIG --cflags SDL2_ttf)
             if [ "$WINDOWS" = "y" ]; then
                 add LDFLAGS $(sdl2-config --static-libs) $($PKG_CONFIG --libs SDL2_ttf)

--- a/src/c/lua.c
+++ b/src/c/lua.c
@@ -89,6 +89,9 @@ void script_init(void)
 	lua_pushstring(L, STRINGIFY(ARCH));
 	lua_setglobal(L, "ARCH");
 
+	lua_pushstring(L, STRINGIFY(FRONTEND));
+	lua_setglobal(L, "FRONTEND");
+
 	lua_newtable(L);
 	lua_setglobal(L, "wg");
 

--- a/src/lua/addons/autosave.lua
+++ b/src/lua/addons/autosave.lua
@@ -154,7 +154,6 @@ function Cmd.ConfigureAutosave()
 		height = 9,
 		stretchy = false,
 
-		["KEY_^C"] = "cancel",
 		["KEY_RETURN"] = "confirm",
 		["KEY_ENTER"] = "confirm",
 		
@@ -181,7 +180,7 @@ function Cmd.ConfigureAutosave()
 	
 	while true do
 		local result = Form.Run(dialogue, RedrawScreen,
-			"SPACE to toggle, RETURN to confirm, CTRL+C to cancel")
+			"SPACE to toggle, RETURN to confirm, "..ESCAPE_KEY.." to cancel")
 		if not result then
 			return false
 		end

--- a/src/lua/addons/debug.lua
+++ b/src/lua/addons/debug.lua
@@ -90,7 +90,6 @@ function Cmd.ConfigureDebug()
 		height = 9,
 		stretchy = false,
 
-		["KEY_^C"] = "cancel",
 		["KEY_RETURN"] = "confirm",
 		["KEY_ENTER"] = "confirm",
 		
@@ -107,7 +106,7 @@ function Cmd.ConfigureDebug()
 	}
 	
 	local result = Form.Run(dialogue, RedrawScreen,
-		"SPACE to toggle, RETURN to confirm, CTRL+C to cancel")
+		"SPACE to toggle, RETURN to confirm, "..ESCAPE_KEY.." to cancel")
 	if not result then
 		return false
 	end

--- a/src/lua/addons/directories.lua
+++ b/src/lua/addons/directories.lua
@@ -83,7 +83,6 @@ function Cmd.ConfigureDirectories()
 		height = 6,
 		stretchy = false,
 
-		["KEY_^C"] = "cancel",
 		["KEY_RETURN"] = "confirm",
 		["KEY_ENTER"] = "confirm",
 		
@@ -112,7 +111,7 @@ function Cmd.ConfigureDirectories()
 	
 	while true do
 		local result = Form.Run(dialogue, RedrawScreen,
-			"SPACE to toggle, RETURN to confirm, CTRL+C to cancel")
+			"SPACE to toggle, RETURN to confirm, "..ESCAPE_KEY.." to cancel")
 		if not result then
 			return false
 		end

--- a/src/lua/addons/docsetman.lua
+++ b/src/lua/addons/docsetman.lua
@@ -98,7 +98,6 @@ function Cmd.ManageDocumentsUI()
 		height = Form.Large,
 		stretchy = false,
 
-		["KEY_^C"] = "cancel",
 		["KEY_RETURN"] = "cancel",
 		["KEY_ENTER"] = "cancel",
 		

--- a/src/lua/addons/goto.lua
+++ b/src/lua/addons/goto.lua
@@ -22,7 +22,6 @@ local function gotobrowser(data, index)
 		height = Form.Large,
 		stretchy = false,
 
-		["KEY_^C"] = "cancel",
 		["KEY_RETURN"] = "confirm",
 		["KEY_ENTER"] = "confirm",
 
@@ -36,7 +35,7 @@ local function gotobrowser(data, index)
 	}
 
 	local result = Form.Run(dialogue, RedrawScreen,
-		"RETURN to select item, CTRL+C to cancel")
+		"RETURN to select item, "..ESCAPE_KEY.." to cancel")
 	QueueRedraw()
 	if result then
 		return browser.cursor

--- a/src/lua/addons/gui.lua
+++ b/src/lua/addons/gui.lua
@@ -91,7 +91,6 @@ function Cmd.ConfigureGui()
 		height = 16,
 		stretchy = false,
 
-		["KEY_^C"] = "cancel",
 		["KEY_RETURN"] = "confirm",
 		["KEY_ENTER"] = "confirm",
 	
@@ -174,7 +173,7 @@ function Cmd.ConfigureGui()
 
 	while true do
 		local result = Form.Run(dialogue, RedrawScreen,
-			"SPACE to toggle, RETURN to confirm, CTRL+C to cancel")
+			"SPACE to toggle, RETURN to confirm, "..ESCAPE_KEY.." to cancel")
 		if not result then
 			return false
 		end

--- a/src/lua/addons/look-and-feel.lua
+++ b/src/lua/addons/look-and-feel.lua
@@ -116,7 +116,6 @@ function Cmd.ConfigureLookAndFeel()
 		height = 11,
 		stretchy = false,
 
-		["KEY_^C"] = "cancel",
 		["KEY_RETURN"] = "confirm",
 		["KEY_ENTER"] = "confirm",
 
@@ -137,7 +136,7 @@ function Cmd.ConfigureLookAndFeel()
 
 	while true do
 		local result = Form.Run(dialogue, RedrawScreen,
-			"SPACE to toggle, RETURN to confirm, CTRL+C to cancel")
+			"SPACE to toggle, RETURN to confirm, "..ESCAPE_KEY.." to cancel")
 		if not result then
 			return false
 		end

--- a/src/lua/addons/scrapbook.lua
+++ b/src/lua/addons/scrapbook.lua
@@ -136,7 +136,6 @@ function Cmd.ConfigureScrapbook()
 		height = 9,
 		stretchy = false,
 
-		["KEY_^C"] = "cancel",
 		["KEY_RETURN"] = "confirm",
 		["KEY_ENTER"] = "confirm",
 		
@@ -163,7 +162,7 @@ function Cmd.ConfigureScrapbook()
 	
 	while true do
 		local result = Form.Run(dialogue, RedrawScreen,
-			"SPACE to toggle, RETURN to confirm, CTRL+C to cancel")
+			"SPACE to toggle, RETURN to confirm, "..ESCAPE_KEY.." to cancel")
 		if not result then
 			return false
 		end

--- a/src/lua/addons/smartquotes.lua
+++ b/src/lua/addons/smartquotes.lua
@@ -241,7 +241,6 @@ function Cmd.ConfigureSmartQuotes()
 		height = 13,
 		stretchy = false,
 
-		["KEY_^C"] = "cancel",
 		["KEY_RETURN"] = "confirm",
 		["KEY_ENTER"] = "confirm",
 
@@ -304,7 +303,7 @@ function Cmd.ConfigureSmartQuotes()
 	}
 
 	local result = Form.Run(dialogue, RedrawScreen,
-		"SPACE to toggle, RETURN to confirm, CTRL+C to cancel")
+		"SPACE to toggle, RETURN to confirm, "..ESCAPE_KEY.." to cancel")
 	if not result then
 		return false
 	end

--- a/src/lua/addons/spillchocker.lua
+++ b/src/lua/addons/spillchocker.lua
@@ -299,7 +299,6 @@ function Cmd.ConfigureSpellchecker()
 		height = 7,
 		stretchy = false,
 
-		["KEY_^C"] = "cancel",
 		["KEY_RETURN"] = "confirm",
 		["KEY_ENTER"] = "confirm",
 
@@ -330,7 +329,7 @@ function Cmd.ConfigureSpellchecker()
 	}
 
 	local result = Form.Run(dialogue, RedrawScreen,
-		"SPACE to toggle, RETURN to confirm, CTRL+C to cancel")
+		"SPACE to toggle, RETURN to confirm, "..ESCAPE_KEY.." to cancel")
 	if not result then
 		return false
 	end

--- a/src/lua/addons/statusbar_pagecount.lua
+++ b/src/lua/addons/statusbar_pagecount.lua
@@ -63,7 +63,6 @@ function Cmd.ConfigurePageCount()
 		height = 5,
 		stretchy = false,
 
-		["KEY_^C"] = "cancel",
 		["KEY_RETURN"] = "confirm",
 		["KEY_ENTER"] = "confirm",
 		
@@ -80,7 +79,7 @@ function Cmd.ConfigurePageCount()
 	
 	while true do
 		local result = Form.Run(dialogue, RedrawScreen,
-			"SPACE to toggle, RETURN to confirm, CTRL+C to cancel")
+			"SPACE to toggle, RETURN to confirm, "..ESCAPE_KEY.." to cancel")
 		if not result then
 			return false
 		end

--- a/src/lua/browser.lua
+++ b/src/lua/browser.lua
@@ -248,7 +248,6 @@ function Browser(title, topmessage, bottommessage, data)
 		height = Form.Large,
 		stretchy = false,
 
-		["KEY_^C"] = "cancel",
 		["KEY_^P"] = go_to_parent,
 		["KEY_RETURN"] = "confirm",
 		["KEY_ENTER"] = "confirm",
@@ -283,7 +282,7 @@ function Browser(title, topmessage, bottommessage, data)
 	}
 	
 	local result = Form.Run(dialogue, RedrawScreen,
-		"RETURN to confirm, CTRL+C to cancel, CTRL+P to go to parent dir")
+		"RETURN to confirm, "..ESCAPE_KEY.." to cancel, CTRL+P to go to parent dir")
 	QueueRedraw()
 	if result then
 		return textfield.value

--- a/src/lua/export/html.lua
+++ b/src/lua/export/html.lua
@@ -237,7 +237,6 @@ function Cmd.ConfigureHTMLExport()
 		height = 13,
 		stretchy = false,
 
-		["KEY_^C"] = "cancel",
 		["KEY_RETURN"] = "confirm",
 		["KEY_ENTER"] = "confirm",
 
@@ -292,7 +291,7 @@ function Cmd.ConfigureHTMLExport()
 	
 	while true do
 		local result = Form.Run(dialogue, RedrawScreen,
-			"SPACE to toggle, RETURN to confirm, CTRL+C to cancel")
+			"SPACE to toggle, RETURN to confirm, "..ESCAPE_KEY.." to cancel")
 		if not result then
 			return false
 		end

--- a/src/lua/forms.lua
+++ b/src/lua/forms.lua
@@ -18,6 +18,7 @@ local Write = wg.write
 local int = math.floor
 local string_rep = string.rep
 
+ESCAPE_KEY = (FRONTEND == "ncurses") and "CTRL+C" or "ESCAPE"
 
 Form = {}
 
@@ -641,8 +642,14 @@ function Form.Run(dialogue, redraw, helptext)
 		end
 
 		if not action then
-			action = findaction(dialogue, dialogue, key) or
-				findaction(standard_actions, dialogue, key)
+			if key == "KEY_^C" then
+				action = "cancel"
+			elseif key == "KEY_ESCAPE" then
+				action = "cancel"
+			else
+				action = findaction(dialogue, dialogue, key) or
+					findaction(standard_actions, dialogue, key)
+			end
 		end
 
 		if (action == "cancel") then

--- a/src/lua/ui.lua
+++ b/src/lua/ui.lua
@@ -88,7 +88,6 @@ function ModalMessage(title, message)
 		height = 2,
 		stretchy = true,
 
-		["KEY_^C"] = "cancel",
 		[" "] = "confirm",
 
 		Form.WrappedLabel {
@@ -122,7 +121,6 @@ function PromptForYesNo(title, message)
 		height = 2,
 		stretchy = true,
 
-		["KEY_^C"] = "cancel",
 		["n"] = rfalse,
 		["N"] = rfalse,
 		["y"] = rtrue,
@@ -135,7 +133,7 @@ function PromptForYesNo(title, message)
 	}
 
 	Form.Run(dialogue, RedrawScreen,
-		"Y for yes, N for no, or CTRL+C to cancel")
+		"Y for yes, N for no, or "..ESCAPE_KEY.." to cancel")
 	QueueRedraw()
 	return result
 end
@@ -159,7 +157,6 @@ function PromptForString(title, message, default)
 		height = 4,
 		stretchy = true,
 
-		["KEY_^C"] = "cancel",
 		["KEY_RETURN"] = "confirm",
 		["KEY_ENTER"] = "confirm",
 
@@ -172,7 +169,7 @@ function PromptForString(title, message, default)
 	}
 
 	local result = Form.Run(dialogue, RedrawScreen,
-		"RETURN to confirm, CTRL+C to cancel")
+		"RETURN to confirm, "..ESCAPE_KEY.." to cancel")
 
 	QueueRedraw()
 	if result then
@@ -204,7 +201,6 @@ function FindAndReplaceDialogue(defaultfind, defaultreplace)
 		width = Form.Large,
 		height = 5,
 
-		["KEY_^C"] = "cancel",
 		["KEY_RETURN"] = "confirm",
 		["KEY_ENTER"] = "confirm",
 
@@ -225,7 +221,7 @@ function FindAndReplaceDialogue(defaultfind, defaultreplace)
 	}
 
 	local result = Form.Run(dialogue, RedrawScreen,
-		"RETURN to confirm, CTRL+C to cancel")
+		"RETURN to confirm, "..ESCAPE_KEY.." to cancel")
 
 	QueueRedraw()
 	if result then
@@ -242,7 +238,6 @@ function AboutDialogue()
 		width = Form.Large,
 		height = 12,
 
-		["KEY_^C"] = "cancel",
 		["KEY_RETURN"] = "confirm",
 		["KEY_ENTER"] = "confirm",
 		[" "] = "confirm",


### PR DESCRIPTION
...as well as CTRL+C. Also, recommend ESCAPE over CTRL+C in help text when on a non-ncurses platform (because of the annoying ESCAPE delay on ncurses).

Fixes: #194