### PR TITLE
Fix crash in the new scroll code.

### DIFF
--- a/src/lua/redraw.lua
+++ b/src/lua/redraw.lua
@@ -240,6 +240,12 @@ function RedrawScreen()
 	if GetScrollMode() == "Fixed" then
 		sp = Document.cp
 		sw = Document.cw
+	else
+		if sp > #Document then
+			sp = #Document
+		elseif sp < 1 then
+			sp = 1
+		end
 	end
 
 	-- Find out the offset of the paragraph at the middle of the screen.


### PR DESCRIPTION
Crash if the scroll position is beyond the bounds of the document (e.g. by deleting lots of text).