### PR TITLE
Fix some issues with locales.

### DIFF
--- a/src/c/globals.h
+++ b/src/c/globals.h
@@ -36,6 +36,7 @@
 
 #if defined(__APPLE__) && defined(__MACH__)
 #define OSX
+#define EMULATED_WCWIDTH
 #endif
 
 #if defined _WIN32

--- a/src/c/main.cc
+++ b/src/c/main.cc
@@ -34,7 +34,7 @@ int main(int argc, char* argv[])
     find_exe();
 #endif
 
-    setlocale(LC_ALL, "");
+    setlocale(LC_ALL, "C.UTF-8");
 #if defined WIN32
     enable_unicode = true;
 #else

--- a/src/c/main.cc
+++ b/src/c/main.cc
@@ -34,10 +34,14 @@ int main(int argc, char* argv[])
     find_exe();
 #endif
 
-    setlocale(LC_ALL, "C.UTF-8");
 #if defined WIN32
+    setlocale(LC_ALL, "C");
+    enable_unicode = true;
+#elif defined OSX
+    setlocale(LC_ALL, "C");
     enable_unicode = true;
 #else
+    setlocale(LC_ALL, "C.UTF-8");
     enable_unicode = strcmp(nl_langinfo(CODESET), "UTF-8") == 0;
 #endif
 


### PR DESCRIPTION
If a locale is used which uses a comma as the decimal separator, Luau fails to parse numbers correctly.

OSX was thinking that UTF-8 was turned off.

Fixes: #239 