### PR TITLE
Ignore backticks when spell checking

### DIFF
--- a/src/lua/document.lua
+++ b/src/lua/document.lua
@@ -232,7 +232,7 @@ end
 function GetWordSimpleText(s: string): string
 	s = GetWordText(s)
 	s = UnSmartquotify(s)
-	s = s:gsub('[~#&^$"<>]+', "")
+	s = s:gsub('[`~#&^$"<>]+', "")
 	s = s:gsub("^[.'([{]+", "")
 	s = s:gsub("[',.!?:;)%]}]+$", "")
 	return s


### PR DESCRIPTION
I use backticks to indicate quotes (similar to LaTex): ``this is in quotes''. However, wordgrinder thinks ``this is a misspelled word, because it doesn't remove the backticks before spell-checking. This commit is an attempt to rectify that.