### PR TITLE
Fix Bug where all exports were blank

### DIFF
--- a/src/lua/export.lua
+++ b/src/lua/export.lua
@@ -190,12 +190,14 @@ function ExportFileWithUI(filename, title, extension, callback)
 
 	ImmediateMessage("Exporting "..filename.."...")
 
-	local data: {string} = {}
-	local writer = function(...: {string})
-		for _, s in ipairs(...) do
-			data[#data+1] = s
-		end
-	end
+        local data: {string} = {}
+        local writer = function(...: string)
+                for _, s in ipairs({...}) do
+                        data[#data+1] = s
+                end
+        end
+
+        callback(writer, currentDocument)
 
 	local _, e = WriteFile(filename, table.concat(data))
 	if e then


### PR DESCRIPTION
Hi! This is a bugfix for https://github.com/davidgiven/wordgrinder/issues/250

Somehow I think you accidentally dropped, amidst your recent refacorings, the export callback. The types on the writer were also off.