### PR TITLE
solves crash at opening non-wg files

### DIFF
--- a/src/lua/fileio.lua
+++ b/src/lua/fileio.lua
@@ -612,7 +612,7 @@ function LoadFromFile(filename): (DocumentSet?, string?)
 	elseif (magic == TMAGIC) then
 		loader = loadfromstreamt
 	else
-		fp:close()
+		--fp:close()
 		return nil, ("'"..filename.."' is not a valid WordGrinder file.")
 	end
 


### PR DESCRIPTION
Wordgrinder crashes/gives error when trying to open (as in "Load document set...") a non-wg file:
```
Lua error: [string "src/lua/fileio.lua"]:615: attempt to call missing method 'close' of table
[string "src/lua/fileio.lua"]:615 function LoadFromFile
[string "src/lua/fileio.lua"]:623 function LoadDocumentSet
[string "src/lua/main.lua"]:167 function WordProcessor
[string "src/lua/main.lua"]:436 function Main
```
I deleted this line, so now it just gives the warning: `[file] is not a valid WordGrinder file`