### PR TITLE
Fix error when trying to save a documentset with no name.

### DIFF
--- a/src/lua/addons/autosave.lua
+++ b/src/lua/addons/autosave.lua
@@ -18,8 +18,11 @@ local function announce()
 end
 
 local function makefilename(pattern: string)
-	local leafname = Leafname(documentSet.name)
-	local dirname = GlobalSettings.directories.autosaves or Dirname(documentSet.name)
+	local name = documentSet.name
+	assert(name)
+
+	local leafname = Leafname(name)
+	local dirname = GlobalSettings.directories.autosaves or Dirname(name)
 	leafname = leafname:gsub("%.wg$", "")
 	leafname = leafname:gsub("%%", "%%%%")
 	
@@ -46,6 +49,11 @@ do
 			settings.lastsaved = os.time()
 		end
 		
+		if not documentSet.name then
+			ImmediateMessage("Cannot autosave; document set has no name!")
+			return
+		end
+
 		if ((os.time() - settings.lastsaved) > (settings.period * 60)) then
 			ImmediateMessage("Autosaving...")
 			

--- a/src/lua/addons/templates.lua
+++ b/src/lua/addons/templates.lua
@@ -24,11 +24,13 @@ function Cmd.SaveCurrentDocumentAsTemplate(): (boolean, string?)
 		filename = filename .. ".wg"
 	end
 
-	documentSet.name = ""
+	local oldname = documentSet.name
+	documentSet.name = nil
 
 	ImmediateMessage("Saving...")
 	documentSet:clean()
 	local r, e = SaveDocumentSetRaw(filename)
+	documentSet.name = oldname
 	if not r then
 		assert(e)
 		ModalMessage("Save failed", "The document could not be saved: "..e)
@@ -58,7 +60,7 @@ function Cmd.CreateDocumentSetFromTemplate(): (boolean, string?)
 	end
 
 	local r, e = Cmd.LoadDocumentSet(filename)
-	documentSet.name = ""
+	documentSet.name = nil
 	return r, e
 end
 
@@ -88,7 +90,7 @@ function Cmd.LoadDefaultTemplate()
 		end
 	end
 
-	documentSet.name = ""
+	documentSet.name = nil
 	return r, e
 end
 

--- a/src/lua/documentset.lua
+++ b/src/lua/documentset.lua
@@ -29,7 +29,7 @@ _G.DocumentSet = DocumentSet
 
 type DocumentSet = {
 	fileformat: number,
-	name: string,
+	name: string?,
 	menu: MenuTree,
 	current: Document,
 	documents: {[number]: Document},

--- a/src/lua/fileio.lua
+++ b/src/lua/fileio.lua
@@ -175,7 +175,8 @@ function Cmd.SaveCurrentDocumentAs(filename: string?): boolean
 
 	ImmediateMessage("Saving...")
 	documentSet:clean()
-	local r, e = SaveDocumentSetRaw(documentSet.name)
+	print(filename)
+	local r, e = SaveDocumentSetRaw(filename)
 	if not r then
 		assert(e)
 		ModalMessage("Save failed", "The document could not be saved: "..e)

--- a/tests/build.py
+++ b/tests/build.py
@@ -57,6 +57,7 @@ TESTS = [
     "weirdness-combining-words",
     "weirdness-delete-word",
     "weirdness-deletion-with-multiple-spaces",
+    "weirdness-documentset-default-name",
     "weirdness-end-of-lines",
     "weirdness-forward-delete",
     "weirdness-globals-applied-on-startup",

--- a/tests/weirdness-documentset-default-name.lua
+++ b/tests/weirdness-documentset-default-name.lua
@@ -1,0 +1,10 @@
+--!nonstrict
+loadfile("tests/testsuite.lua")()
+
+AssertEquals(documentSet.name, nil)
+
+ResetDocumentSet()
+AssertEquals(documentSet.name, nil)
+
+Cmd.LoadDefaultTemplate()
+AssertEquals(documentSet.name, nil)

--- a/tools/typechecker.cc
+++ b/tools/typechecker.cc
@@ -167,5 +167,5 @@ int main(int argc, char* const* argv)
     }
     printf("(%d errors)\n", count);
 
-    return 0;
+    return count ? 1 : 0;
 }


### PR DESCRIPTION
Also generally improve the handling of this situation (DocumentSet.name is now nullable).

Fixes: #289 