### PR TITLE
Fix wordcount displaying paragraphs and spaces

### DIFF
--- a/src/lua/document.lua
+++ b/src/lua/document.lua
@@ -187,8 +187,14 @@ function Document.renumber(self: Document)
 	local wc = 0
 	local pn = 1
 
+--i think i fixed the page count bug?
+
 	for _, p in ipairs(self) do
-		wc = wc + #p
+		for _, word in ipairs(p) do
+			if GetWordText(word) ~= "" then
+				wc = wc +1
+			end
+		end
 
 		local style = documentStyles[p.style]
 		if style.numbered then

--- a/src/lua/fileio.lua
+++ b/src/lua/fileio.lua
@@ -18,6 +18,8 @@ local escape = wg.escape
 local unescape = wg.unescape
 local string_format = string.format
 local unpack = rawget(_G, "unpack") or table.unpack
+-- bound this for page count bug fix
+local GetWordText = wg.getwordtext
 
 local MAGIC = "WordGrinder dumpfile v1: this is not a text file!"
 local ZMAGIC = "WordGrinder dumpfile v2: this is not a text file!"
@@ -721,8 +723,14 @@ function UpgradeDocument(oldversion)
 		for _, document in ipairs(documentSet.documents) do
 			local wc = 0
 
+-- page count bug fix
+
 			for _, p in ipairs(document) do
-				wc = wc + #p
+				for _, word in ipairs(p) do
+					if GetWordText(word) ~= "" then
+						wc = wc + 1
+					end
+				end
 			end
 
 			document.wordcount = wc


### PR DESCRIPTION
Bug: The status bar displayed the word count incorrectly and counted empty paragraphs and whitespaces as words

Fix: removed #p from counting and updated src/lua/document.lua and src/lua/fileio.lua with GetWordText(word) ~= to only count actual words