### PR TITLE
Escape block markers on Markdown export so plain text round-trips

### DIFF
--- a/src/lua/export/markdown.lua
+++ b/src/lua/export/markdown.lua
@@ -8,6 +8,12 @@ local function unmarkdown(s)
 	s = s:gsub("`", "\\`")
 	s = s:gsub("_", "\\_")
 	s = s:gsub("*", "\\*")
+
+	-- Neutralise block markers so plain text round-trips (otherwise cmark
+	-- re-reads them as a thematic break / list and we lose or mangle text).
+	s = s:gsub("^(%d+)([.)])$", "%1\\%2")  -- ordered-list marker: "1." -> "1\."
+	s = s:gsub("^([-=]+)$", "\\%1")        -- "---"/"===" thematic-break/setext -> "\---"
+	s = s:gsub("^%+$", "\\+")              -- "+" bullet -> "\+"
 	return s
 end
 

--- a/tests/export-to-markdown.lua
+++ b/tests/export-to-markdown.lua
@@ -60,3 +60,38 @@ normal text again
 local output = Cmd.ExportToMarkdownString()
 AssertEquals(expected, output)
 
+-- Regression test for issue #316: plain text that looks like a Markdown block
+-- marker must round-trip through .md export and import unchanged. Without
+-- escaping, cmark re-reads "---" as a thematic break (and the paragraph
+-- vanishes entirely), "1." as an ordered-list item, and "+" as a bullet.
+
+ResetDocumentSet()
+Cmd.InsertStringIntoParagraph("Chapter ends here.")
+Cmd.SplitCurrentParagraph()
+Cmd.InsertStringIntoParagraph("---")
+Cmd.SplitCurrentParagraph()
+Cmd.InsertStringIntoParagraph("New scene begins.")
+Cmd.SplitCurrentParagraph()
+Cmd.InsertStringIntoParagraph("1. First reason")
+Cmd.SplitCurrentParagraph()
+Cmd.InsertStringIntoParagraph("+ plus bullet")
+Cmd.ChangeParagraphStyle("P")
+local original_text = Cmd.ExportToTextString()
+
+-- The block markers must be escaped in the exported markdown.
+local roundtrip = Cmd.ExportToMarkdownString()
+AssertEquals(true, roundtrip:find("\\---", 1, true) ~= nil)
+AssertEquals(true, roundtrip:find("1\\.", 1, true) ~= nil)
+AssertEquals(true, roundtrip:find("\\+", 1, true) ~= nil)
+
+-- And re-importing the export must reproduce the original plain text, with the
+-- "---" paragraph still present and the list-like lines still ordinary
+-- paragraphs.
+-- (cmark always prepends an empty leading paragraph on import, so compare
+-- against the original text with a matching leading blank line.)
+local reimported = Cmd.ImportMarkdownString(roundtrip)
+documentSet:addDocument(reimported, "reimported")
+documentSet:setCurrent("reimported")
+local roundtripped_text = Cmd.ExportToTextString()
+AssertEquals("\n" .. original_text, roundtripped_text)
+


### PR DESCRIPTION
Hi David — thanks for WordGrinder, it's a lovely tool to write in.

While round-tripping documents through Markdown I hit issue #316: a paragraph whose text *looks like* a block marker gets lost or mangled on `.md` export. A paragraph that is `---` round-trips to nothing (cmark reads it as a thematic break and the paragraph vanishes); a paragraph starting `1.` / `1)` loses the `N.` / `N)` (read as an ordered-list item); and a `+` paragraph loses the bullet.

Minimal repro:

```
printf 'Chapter ends here.\n---\nNew scene begins.\n1. First reason\n+ plus bullet\n' > in.txt
wordgrinder --convert in.txt doc.wg
wordgrinder --convert doc.wg out.md
wordgrinder --convert out.md back.wg
wordgrinder --convert back.wg back.txt
cat back.txt   # before: "---" gone, "1." and "+" eaten
```

Root cause: `unmarkdown()` in `src/lua/export/markdown.lua` already escapes the inline markers (`#`, `*`, `_`, backtick, `<`, `>`), so the intent is clearly round-trip-safe export — it just misses the thematic-break/setext sequences (`---` / `===`), the ordered-list markers (`N.` / `N)`), and the `+` bullet. Since `unmarkdown()` runs per word, an anchored pattern matches a word that is wholly a marker, and escaping it (`\---`, `1\.`, `\+`) makes cmark re-read it as literal text on import.

A round-trip regression test is included in `tests/export-to-markdown.lua` (export must contain the escaped forms, and re-importing the export must reproduce the original text), and the full suite passes.

Fixes #316